### PR TITLE
Prisma schema change and migration

### DIFF
--- a/prisma/migrations/20250709154747_add_pass_to_acc/migration.sql
+++ b/prisma/migrations/20250709154747_add_pass_to_acc/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Account" ADD COLUMN     "password" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -42,6 +42,7 @@ model Account {
     session_state            String?
     user                     User    @relation(fields: [userId], references: [id], onDelete: Cascade)
     refresh_token_expires_in Int?
+    password                 String? @db.Text // Added for storing hashed passwords
 
     @@unique([provider, providerAccountId])
 }

--- a/src/server/api/routers/auth.ts
+++ b/src/server/api/routers/auth.ts
@@ -32,9 +32,7 @@ export const authRouter = createTRPCRouter({
       // Hash password with bcrypt
       const hashedPassword = await hash(password, HASH_ROUNDS);
 
-      // Create user
-      // Note: We're temporarily storing the hashed password in providerAccountId
-      // This will be moved to a proper password field in the next PR
+      // Create user with proper password storage
       const user = await ctx.db.user.create({
         data: {
           email,
@@ -42,7 +40,8 @@ export const authRouter = createTRPCRouter({
             create: {
               type: "credentials",
               provider: "credentials",
-              providerAccountId: hashedPassword,
+              providerAccountId: email, // Use email as the provider account ID
+              password: hashedPassword, // Store hashed password in the dedicated field
             },
           },
         },


### PR DESCRIPTION
- Added a new 'password' column to the Account model in the Prisma schema for storing hashed passwords.
- Updated the migration SQL to reflect the addition of the password field.
- Modified the user creation logic in the authRouter to store the hashed password in the new field instead of providerAccountId.
- Resolves : #11 