### PR TITLE
Remove duplicate notification alert cards for a cleaner interface

### DIFF
--- a/src/app/notifications/page.tsx
+++ b/src/app/notifications/page.tsx
@@ -128,42 +128,7 @@ export default function NotificationPage() {
             indicate errors.
           </p>
         </div>
-        {/* Phone Calls Card */}
-        <div className="bg-gray-950 rounded-2xl border border-pink-500 shadow-xl p-12 flex flex-col justify-center min-h-[190px]">
-         <h3 className="text-2xl font-bold mb-3 text-pink-600 dark:text-pink-300">
-            <span className="text-pink-500 dark:text-pink-300">Phone</span> Calls
-          </h3>
-          <p className="text-gray-200 text-lg">
-            We allow you to receive direct phone calls for alerts that require immediate attention. An automated recording will read your alert out loud when you answer. Never miss an urgent event in crypto.
-          </p>
-        </div>
-        {/* Push Notifications Card */}
-        <div className="bg-gray-950 rounded-2xl border border-pink-500 shadow-xl p-12 flex flex-col justify-center min-h-[190px]">
-          <h3 className="text-2xl font-bold mb-3 text-pink-600 dark:text-pink-300">
-            <span className="text-pink-500 dark:text-pink-300">Push</span> Notifications
-          </h3>
-          <p className="text-gray-200 text-lg">
-            Push notifications can be sent to any iOS or Android device by simply downloading our app. You can also manage your alerts and view your notification history from the app itself.
-          </p>
-        </div>
-        {/* Browser Notifications Card */}
-        <div className="bg-gray-950 rounded-2xl border border-pink-500 shadow-xl p-12 flex flex-col justify-center min-h-[190px]">
-          <h3 className="text-2xl font-bold mb-3 text-pink-600 dark:text-pink-300">
-            <span className="text-pink-500 dark:text-pink-300">Browser</span> Notifications
-          </h3>
-          <p className="text-gray-200 text-lg">
-            Browser notifications allow you to receive alerts right on your desktop — even if this tab is closed! Visit our <span className="text-green-400">FAQ</span> to learn more.
-          </p>
-        </div>
-        {/* Telegram Bot Card */}
-        <div className="bg-gray-950 rounded-2xl border border-pink-500 shadow-xl p-12 flex flex-col justify-center min-h-[190px]">
-          <h3 className="text-2xl font-bold mb-3 text-pink-600 dark:text-pink-300">
-            <span className="text-pink-500 dark:text-pink-300">Telegram</span> Bot
-          </h3>
-          <p className="text-gray-200 text-lg">
-            Use our Telegram bot to receive unlimited customizable crypto alerts. We support both Telegram groups and individual users.
-          </p>
-        </div>
+       
       </div>
     </div>
   );


### PR DESCRIPTION
- Removed repeated notification cards (Phone Calls, Push Notifications, Browser Notifications, Telegram Bot) from the alerts page.
- Now each notification method card appears only once, ensuring a clean and intuitive user experience.
- This change prevents confusion and maintains UI consistency across the alert section.
- No functional logic affected—purely visual code cleanup.
